### PR TITLE
アプリケーション作成 #2: ボタンを Grid, Container コンポーネントでレイアウトする

### DIFF
--- a/src/containers/MultiplyButtons.js
+++ b/src/containers/MultiplyButtons.js
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import Button from "@material-ui/core/Button";
+import Grid from '@material-ui/core/Grid';
+import Container from '@material-ui/core/Container';
 
 function MultiplyButtons() {
   const [buttons, setButtons] = useState(["Button"]);
@@ -7,15 +9,23 @@ function MultiplyButtons() {
     setButtons([...buttons, "Button"]);
   };
   return (
-    <div>
-      {buttons.map((button, index) => (
-        <>
-          <Button key={index} variant="contained" onClick={handleButtonClick}>
-            Default
-          </Button>
-        </>
-      ))}
-    </div>
+    <Container>
+      <Grid container spacing={1} justify="space-between">
+        {buttons.map((button, index) => (
+          <>
+            <Grid container item xs={2}>
+              <Button
+                key={index}
+                variant="contained"
+                onClick={handleButtonClick}
+              >
+                Default
+              </Button>
+            </Grid>
+          </>
+        ))}
+      </Grid>
+    </Container>
   );
 }
 


### PR DESCRIPTION
ref: #6 

![screenshots25](https://user-images.githubusercontent.com/37991437/85820840-1efa4000-b7b2-11ea-84e6-80f32fbcca2f.gif)

# ボタンを Grid コンポーネントでレイアウトする
- `import Grid from '@material-ui/core/Grid';`
```
      <Grid container spacing={1}>
        {buttons.map((button, index) => (
          <>
            <Grid container item xs={12} spacing={3}>
              <Button
                key={index}
                variant="contained"
                onClick={handleButtonClick}
              >
                Default
              </Button>
            </Grid>
          </>
        ))}
      </Grid>
```
- おかしい
<img width="181" alt="スクリーンショット 2020-06-26 13 06 41" src="https://user-images.githubusercontent.com/37991437/85819194-e8bac180-b7ad-11ea-8405-91ce05a2c9d2.png">

- ` spacing={3}` 削除
- 縦並びになる。横並びにしたい
- xs={12} を xs={1} に
- Grid は最大12個 https://qiita.com/vimyum/items/5ba06ca166ebe4992617
- :tada:

# Container コンポーネントでラップする
- はみ出ているので修正したい
- `import Container from '@material-ui/core/Container';`
- 収まった
- xs1だと狭いのでxs2に
- 見栄えが悪かったので justify="center" を指定
- まだ見栄えが悪い => 見たら grid アイテムの中に余白があった
- ここで対応することではないと思うので一旦 :tada: