### PR TITLE
Redux 導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1"
+    "react-redux": "^7.2.0",
+    "react-scripts": "3.4.1",
+    "redux": "^4.0.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 // initial
-import React from 'react';
+import React, { Component } from 'react';
 import './App.css';
 import PropTypes from 'prop-types';
 
@@ -10,12 +10,14 @@ import { increment, decrement } from './actions/counter';
 // components
 import Counter from './components/counter';
 
-function App() {
-  return (
-    <div className="App">
-      <Counter {...this.props} />
-    </div>
-  );
+class App extends Component {
+  render() {
+    return (
+      <div className="App">
+        <Counter {...this.props} />
+      </div>
+    );
+  }
 }
 
 // proptypes

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,44 @@
+// initial
 import React from 'react';
 import './App.css';
+import PropTypes from 'prop-types';
 
-import MultiplyButtons from './containers/MultiplyButtons'
+// redux
+import { connect } from 'react-redux';
+import { increment, decrement } from './actions/counter';
+
+// components
+import Counter from './components/counter';
 
 function App() {
   return (
     <div className="App">
-      <MultiplyButtons />
+      <Counter {...this.props} />
     </div>
   );
 }
 
-export default App;
+// proptypes
+App.propTypes = {
+  counter: PropTypes.object.isRequired,
+  dispatch_increment: PropTypes.func.isRequired,
+  dispatch_decrement: PropTypes.func.isRequired
+}
+
+// redux settings
+// state => props
+function mapStateToProps(state) {
+  return {
+    counter: state.counterReducer,
+  }
+}
+
+// dispatch => props
+function mapDispatchToProps(dispatch) {
+  return {
+    dispatch_increment: () => dispatch(increment()),
+    dispatch_decrement: () => dispatch(decrement())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/actions/counter.js
+++ b/src/actions/counter.js
@@ -1,0 +1,13 @@
+// src/actions/counter.js
+// Action Types
+export const INCREMENT = 'INCREMENT';
+export const DECREMENT = 'DECREMENT';
+
+// Actions
+export function increment() {
+  return { type: INCREMENT }
+}
+
+export function decrement() {
+  return { type: DECREMENT }
+}

--- a/src/components/counter.js
+++ b/src/components/counter.js
@@ -1,0 +1,18 @@
+// src/components/counter.js
+import React, { Component } from 'react';
+
+class Counter extends Component {
+  render() {
+   let { counter, dispatch_increment, dispatch_decrement } = this.props;
+   console.log(counter.note)
+   return (
+     <div>
+       <div>{counter.count}</div>
+       <button onClick={dispatch_increment}>+</button>
+       <button onClick={dispatch_decrement}>-</button>
+     </div>
+   );
+  }
+}
+
+export default Counter;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,22 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import * as serviceWorker from "./serviceWorker";
+
+// redux
+import { createStore } from "redux";
+import rootReducer from "./reducers/index";
+import { Provider } from "react-redux";
+
+// create store
+const store = createStore(rootReducer);
 
 ReactDOM.render(
-  <React.StrictMode>
+  <Provider store={store}>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </Provider>,
+  document.getElementById("root")
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/reducers/counter.js
+++ b/src/reducers/counter.js
@@ -1,0 +1,26 @@
+// src/reducers/counter.js
+import { INCREMENT, DECREMENT } from '../actions/counter';
+
+const initialState = {
+  count: 10,
+  note: 'default'
+};
+
+export function counterReducer(state = initialState, action){
+  switch(action.type) {
+    case INCREMENT:
+      return {
+        ...state,
+        count: ++state.count,
+        note: 'increment'
+      };
+    case DECREMENT:
+      return {
+        ...state,
+        count: --state.count,
+        note: 'decrement'
+      };
+    default:
+      return state;
+  }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,10 @@
+// src/reducers/index.js
+import { combineReducers } from 'redux';
+import { counterReducer } from './counter';
+
+const rootReducer = combineReducers({
+  // 状態ごとのReducer
+  counterReducer,
+})
+
+export default rootReducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5880,7 +5880,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9761,7 +9761,7 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.0:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9770,6 +9770,17 @@ react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-redux@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-scripts@3.4.1:
   version "3.4.1"
@@ -9943,6 +9954,14 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
@@ -11154,6 +11173,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"


### PR DESCRIPTION
ref: #11 
<img width="1016" alt="スクリーンショット 2020-06-29 17 21 19" src="https://user-images.githubusercontent.com/37991437/85990457-08135200-ba2d-11ea-8f9d-8c0eac3854e1.png">

# Redux 導入
参考: https://qiita.com/daiki7nohe/items/3ae705c0d4c8a4aff425
- `createStore(xxx)` Store を作成
- `<Provider store={store}>` Store を提供
- src/actions/counter.js Actions を定義
  - type (必須)
- Reducer
  - Reducerは定義したActionを元に状態の変更を行います。Reducer(還元剤)なので、変更後の状態は副作用のないものでなければなりません。
- Actions を流してActionを元に状態の変更を行う
- 全てのReducerを取りまとめるRootのReducerを用意
- Container Components: Presentational Componentsとこれまで用意したReduxアーキテクチャ(Reducers, Actions, Store)をつなぐためのコンポーネント
- Presentational Components: 見た目部分を担当しているコンポーネント
- Container Components でPresentational Components と Redux アーキテクチャをつなぐ
- Presentational Components で Redux アーキテクチャを呼び出す